### PR TITLE
fix: scope update to tag prefix for multi-version-line repos

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ lib/
 5. Write lock file entry
 
 **Data flow for `update`:**
-1. Call `getLatestTag()` per repo to find newest release
+1. Call `getLatestTag()` per repo to find newest release (or `getLatestTagByPrefix()` when the entry sets `tagPrefix`, for repos hosting multiple version lines)
 2. Verify the expected asset name exists in that release
 3. Patch version in config JSON in-place (preserves formatting via string replace)
 4. Call `installOne()` with `clean=true` to force re-extraction
@@ -65,6 +65,7 @@ lib/
 - `dir` (optional): default install directory; CLI `--dir` overrides it; falls back to `Plugins`
 - `--config` defaults to `plugins` and auto-appends `.json` if no extension given
 - The `{version}` placeholder in `asset` is substituted at runtime. Lock file is auto-derived: `plugins.json` → `plugins-lock.json`.
+- Per-entry `tagPrefix` scopes `update` to releases whose `tag_name` starts with the prefix (one repo, multiple version lines).
 
 ## Publishing
 

--- a/README.md
+++ b/README.md
@@ -43,5 +43,21 @@ npx ue-assets update MyPlugin
 
 - `"dir"` (optional): default install directory; CLI `--dir` overrides it; falls back to `Plugins/`
 - `"dest"` per entry overrides the install directory for that specific asset
+- `"tagPrefix"` per entry scopes `update` to releases whose tag starts with the prefix — use when a single repo hosts multiple independent version lines (e.g. `designpacks-v1.0.0`, `alphabrushes-v1.0.0`)
 
 A `*-lock.json` is written alongside the config to skip already-installed versions.
+
+### Multiple version lines in one repo
+
+```json
+{
+  "plugins": {
+    "Brushify_DesignPacks": {
+      "repo": "echoulen/brushify",
+      "tagPrefix": "designpacks-",
+      "version": "designpacks-v1.0.0",
+      "asset": "Brushify_DesignPacks-{version}.zip"
+    }
+  }
+}
+```

--- a/lib/github.js
+++ b/lib/github.js
@@ -31,6 +31,36 @@ async function getLatestTag(repo) {
 }
 
 /**
+ * Get the latest release tag whose name starts with the given prefix.
+ * Used when a single repo hosts multiple independent version lines.
+ * Paginates through releases (newest first) until a match is found.
+ * @param {string} repo  "owner/name"
+ * @param {string} prefix
+ * @returns {Promise<string>}
+ */
+async function getLatestTagByPrefix(repo, prefix) {
+  const { owner, name } = splitRepo(repo);
+  const octokit = getOctokit();
+  const perPage = 100;
+  const maxPages = 5;
+
+  for (let page = 1; page <= maxPages; page++) {
+    const { data } = await octokit.repos.listReleases({
+      owner,
+      repo: name,
+      per_page: perPage,
+      page,
+    });
+    if (data.length === 0) break;
+    const match = data.find((r) => r.tag_name.startsWith(prefix));
+    if (match) return match.tag_name;
+    if (data.length < perPage) break;
+  }
+
+  throw new Error(`No release found in ${repo} with tag prefix '${prefix}'`);
+}
+
+/**
  * List asset names for a specific release tag.
  * @param {string} repo  "owner/name"
  * @param {string} tag
@@ -100,4 +130,4 @@ async function downloadAsset(repo, tag, assetName, destPath) {
   fs.writeFileSync(destPath, Buffer.concat(chunks));
 }
 
-module.exports = { getLatestTag, listAssetNames, downloadAsset };
+module.exports = { getLatestTag, getLatestTagByPrefix, listAssetNames, downloadAsset };

--- a/lib/update.js
+++ b/lib/update.js
@@ -3,7 +3,7 @@
 const fs = require('fs');
 const path = require('path');
 const chalk = require('chalk');
-const { getLatestTag, listAssetNames } = require('./github');
+const { getLatestTag, getLatestTagByPrefix, listAssetNames } = require('./github');
 const { lockPathFor } = require('./lockfile');
 const { install, installOne, readConfig, resolveConfigPath } = require('./install');
 
@@ -51,10 +51,12 @@ async function update(targetName, opts) {
     console.log();
     info(`[${i + 1}/${names.length}] Checking ${name} (current: ${entry.version})`);
 
-    // Fetch latest tag
+    // Fetch latest tag (prefix-scoped when configured — supports repos hosting multiple version lines)
     let latestTag;
     try {
-      latestTag = await getLatestTag(entry.repo);
+      latestTag = entry.tagPrefix
+        ? await getLatestTagByPrefix(entry.repo, entry.tagPrefix)
+        : await getLatestTag(entry.repo);
     } catch (err) {
       warn(`  Could not fetch latest release for ${entry.repo} — ${err.message}`);
       failed++;


### PR DESCRIPTION
## Summary
- Add optional per-entry `tagPrefix` in config — when set, `update` resolves the latest tag by listing releases and picking the newest whose `tag_name` starts with that prefix
- Falls back to the existing `repos.getLatestRelease` path when `tagPrefix` is absent (fully backward-compatible)
- Document the new field in README and CLAUDE.md

Closes #1

## Test plan
- [ ] `ue-assets update Brushify_DesignPacks` against a repo with interleaved tag prefixes resolves to the newest `designpacks-*` tag
- [ ] Existing single-version-line configs (no `tagPrefix`) still use `getLatestRelease`
- [ ] Missing-prefix case surfaces a readable `No release found … with tag prefix` warning and continues to the next entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)